### PR TITLE
Ensure buildUrl always uses relative paths

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -19,7 +19,7 @@ function resolveBaseUrl(baseUrl) {
 
 function buildUrl(baseUrl, path, query) {
   const normalisedBase = resolveBaseUrl(baseUrl);
-  const normalisedPath = path.startsWith('/') ? path : `/${path}`;
+  const normalisedPath = path.replace(/^\/+/, '');
   const url = new URL(normalisedPath, `${normalisedBase}/`);
 
   if (query) {


### PR DESCRIPTION
## Summary
- strip any leading slash from the path passed to `buildUrl`
- rely on relative URL resolution so requests stay under `/.netlify/functions/airtable`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e02d75ab2c8321825593e1af2c34fc