### PR TITLE
Fix Airtable function path normalization

### DIFF
--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -264,7 +264,12 @@ function normalisePath(event) {
   const path = event.path || '';
   const prefixMatch = path.match(/\.netlify\/functions\/[^/]+/);
   if (!prefixMatch) return path;
-  return path.slice(prefixMatch[0].length);
+  const start = prefixMatch.index ?? 0;
+  const trimmed = path.slice(start + prefixMatch[0].length);
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
 }
 
 function linkFilter(field, id) {


### PR DESCRIPTION
## Summary
- update the Airtable function path normalisation to respect the matched prefix index
- ensure normalised paths retain a leading slash so session routes resolve correctly

## Testing
- node - <<'NODE' … (mocked handler GET /.netlify/functions/airtable/sessions)


------
https://chatgpt.com/codex/tasks/task_b_68e03025c31083219b43777d0d99cc7e