### PR TITLE
Fix Netlify airtable path normalisation

### DIFF
--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -264,8 +264,19 @@ function normalisePath(event) {
   const path = event.path || '';
   const prefixMatch = path.match(/\.netlify\/functions\/[^/]+/);
   if (!prefixMatch) return path;
-  const start = prefixMatch.index ?? 0;
-  const trimmed = path.slice(start + prefixMatch[0].length);
+  const matchText = prefixMatch[0];
+  const start =
+    typeof prefixMatch.index === 'number'
+      ? prefixMatch.index
+      : path.indexOf(matchText);
+  if (start === -1) {
+    return path;
+  }
+  let trimmed = path.slice(start + matchText.length);
+  const fragmentIndex = trimmed.search(/[?#]/);
+  if (fragmentIndex !== -1) {
+    trimmed = trimmed.slice(0, fragmentIndex);
+  }
   if (!trimmed) {
     return '';
   }
@@ -575,3 +586,5 @@ exports.handler = async (event) => {
     return errorResponse(error);
   }
 };
+
+exports._normalisePath = normalisePath;

--- a/scripts/normalise-path-repro.js
+++ b/scripts/normalise-path-repro.js
@@ -1,0 +1,52 @@
+const requiredEnv = [
+  'AIRTABLE_API_KEY',
+  'AIRTABLE_BASE_ID',
+  'BOARDS_TABLE_ID',
+  'SESSIONS_TABLE_ID',
+  'TOPICS_TABLE_ID',
+  'VOTES_TABLE_ID',
+  'COMMENTS_TABLE_ID',
+  'USERS_TABLE_ID',
+];
+
+for (const key of requiredEnv) {
+  if (!process.env[key]) {
+    process.env[key] = 'test';
+  }
+}
+
+const assert = require('node:assert/strict');
+const { _normalisePath } = require('../netlify/functions/airtable');
+
+if (typeof _normalisePath !== 'function') {
+  throw new Error('normalisePath export missing');
+}
+
+const originalMatch = String.prototype.match;
+String.prototype.match = function patchedMatch(regex) {
+  const result = originalMatch.call(this, regex);
+  if (!result) {
+    return result;
+  }
+  const clone = Array.from(result);
+  clone.input = result.input;
+  clone.groups = result.groups;
+  return clone;
+};
+
+try {
+  const normalised = _normalisePath({ path: '/.netlify/functions/airtable/sessions' });
+  assert.strictEqual(normalised, '/sessions');
+  console.log('normalisePath without match index ->', normalised);
+} finally {
+  String.prototype.match = originalMatch;
+}
+
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable' }), '');
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable?foo=bar' }), '');
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable#fragment' }), '');
+assert.strictEqual(
+  _normalisePath({ path: '/.netlify/functions/airtable/topics?foo=bar' }),
+  '/topics'
+);
+console.log('Additional normalisePath assertions passed');


### PR DESCRIPTION
## Summary
- ensure the Airtable function path normaliser handles matches without an index and trims query/fragment suffixes
- expose the helper and add a manual reproduction script covering the missing-index case

## Testing
- node scripts/normalise-path-repro.js

------
https://chatgpt.com/codex/tasks/task_b_68e3e93eb7dc8321b91b0fc4c9039c68