### PR TITLE
Improve Airtable path detection across Netlify variants

### DIFF
--- a/scripts/normalise-path-repro.js
+++ b/scripts/normalise-path-repro.js
@@ -1,0 +1,66 @@
+const requiredEnv = [
+  'AIRTABLE_API_KEY',
+  'AIRTABLE_BASE_ID',
+  'BOARDS_TABLE_ID',
+  'SESSIONS_TABLE_ID',
+  'TOPICS_TABLE_ID',
+  'VOTES_TABLE_ID',
+  'COMMENTS_TABLE_ID',
+  'USERS_TABLE_ID',
+];
+
+for (const key of requiredEnv) {
+  if (!process.env[key]) {
+    process.env[key] = 'test';
+  }
+}
+
+const assert = require('node:assert/strict');
+const { _normalisePath } = require('../netlify/functions/airtable');
+
+if (typeof _normalisePath !== 'function') {
+  throw new Error('normalisePath export missing');
+}
+
+const originalMatch = String.prototype.match;
+String.prototype.match = function patchedMatch(regex) {
+  const result = originalMatch.call(this, regex);
+  if (!result) {
+    return result;
+  }
+  const clone = Array.from(result);
+  clone.input = result.input;
+  clone.groups = result.groups;
+  return clone;
+};
+
+try {
+  const normalised = _normalisePath({ path: '/.netlify/functions/airtable/sessions' });
+  assert.strictEqual(normalised, '/sessions');
+  console.log('normalisePath without match index ->', normalised);
+} finally {
+  String.prototype.match = originalMatch;
+}
+
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable' }), '');
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable?foo=bar' }), '');
+assert.strictEqual(_normalisePath({ path: '/.netlify/functions/airtable#fragment' }), '');
+assert.strictEqual(
+  _normalisePath({ path: '/.netlify/functions/airtable/topics?foo=bar' }),
+  '/topics'
+);
+assert.strictEqual(
+  _normalisePath({
+    path: '/.netlify/functions/airtable',
+    rawUrl: 'https://example.com/.netlify/functions/airtable/sessions?foo=bar',
+  }),
+  '/sessions'
+);
+assert.strictEqual(
+  _normalisePath({
+    path: '/.netlify/functions/airtable',
+    headers: { 'x-nf-original-pathname': '/.netlify/functions/airtable/topics#hash' },
+  }),
+  '/topics'
+);
+console.log('Additional normalisePath assertions passed');

--- a/test/normalise-path.test.js
+++ b/test/normalise-path.test.js
@@ -1,0 +1,71 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const requiredEnv = [
+  'AIRTABLE_API_KEY',
+  'AIRTABLE_BASE_ID',
+  'BOARDS_TABLE_ID',
+  'SESSIONS_TABLE_ID',
+  'TOPICS_TABLE_ID',
+  'VOTES_TABLE_ID',
+  'COMMENTS_TABLE_ID',
+  'USERS_TABLE_ID',
+];
+
+for (const key of requiredEnv) {
+  if (!process.env[key]) {
+    process.env[key] = 'test';
+  }
+}
+
+const { _normalisePath } = require('../netlify/functions/airtable');
+
+test('handles matches missing an index property', () => {
+  const originalMatch = String.prototype.match;
+  try {
+    String.prototype.match = function patchedMatch(regex) {
+      const result = originalMatch.call(this, regex);
+      if (!result) {
+        return result;
+      }
+      const clone = Array.from(result);
+      clone.input = result.input;
+      clone.groups = result.groups;
+      return clone;
+    };
+    const normalised = _normalisePath({ path: '/.netlify/functions/airtable/sessions' });
+    assert.equal(normalised, '/sessions');
+  } finally {
+    String.prototype.match = originalMatch;
+  }
+});
+
+test('prefers non-empty matches when multiple candidates exist', () => {
+  assert.equal(
+    _normalisePath({
+      path: '/.netlify/functions/airtable',
+      rawUrl: 'https://example.com/.netlify/functions/airtable/topics?foo=bar',
+    }),
+    '/topics'
+  );
+});
+
+test('falls back to Netlify original path headers', () => {
+  assert.equal(
+    _normalisePath({
+      path: '/.netlify/functions/airtable',
+      headers: {
+        'x-nf-original-pathname': '/.netlify/functions/airtable/votes#hash',
+      },
+    }),
+    '/votes'
+  );
+});
+
+test('returns an empty string when only the root function path matches', () => {
+  assert.equal(_normalisePath({ path: '/.netlify/functions/airtable' }), '');
+});
+
+test('returns the first candidate when nothing matches', () => {
+  assert.equal(_normalisePath({ path: '/api/airtable' }), '/api/airtable');
+});


### PR DESCRIPTION
## Summary
- expand the Airtable function path normaliser to consider rawUrl, rawPath, original headers, and requestContext paths while preferring the most specific match
- update the manual reproduction script to cover the new header fallback scenario
- add automated node:test coverage for the normalisePath helper across the new edge cases

## Testing
- node scripts/normalise-path-repro.js
- node --test test/normalise-path.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e3e93eb7dc8321b91b0fc4c9039c68