### PR TITLE
Expose Airtable API base constant

### DIFF
--- a/netlify/functions/airtable.js
+++ b/netlify/functions/airtable.js
@@ -602,4 +602,5 @@ exports.handler = async (event) => {
   }
 };
 
+exports.AIRTABLE_API_BASE = AIRTABLE_API_BASE;
 exports._normalisePath = normalisePath;


### PR DESCRIPTION
## Summary
- export the `AIRTABLE_API_BASE` constant from the Airtable Netlify function so other modules can import it

## Testing
- node --test *(fails: existing normalise-path tests)*

------
https://chatgpt.com/codex/tasks/task_b_68e433eb71e88321838edf5453392d4e