### PR TITLE
Add PATCH board handler and theme metadata mapping

### DIFF
--- a/test/airtable-config.test.js
+++ b/test/airtable-config.test.js
@@ -33,6 +33,27 @@ function withRequiredEnv(fn) {
   }
 }
 
+async function withRequiredEnvAsync(fn) {
+  const previous = {};
+  for (const key of requiredEnv) {
+    previous[key] = process.env[key];
+    if (!process.env[key]) {
+      process.env[key] = 'test';
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of requiredEnv) {
+      if (previous[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
 function freshModule() {
   const modulePath = require.resolve('../netlify/functions/airtable');
   delete require.cache[modulePath];
@@ -67,6 +88,69 @@ test('allows overriding the Airtable API base domain for testing', () => {
       delete process.env.AIRTABLE_API_BASE_URL;
     } else {
       process.env.AIRTABLE_API_BASE_URL = previousBase;
+    }
+  });
+});
+
+test('PATCH /boards/:id updates theme metadata', async () => {
+  await withRequiredEnvAsync(async () => {
+    const originalFetch = global.fetch;
+    const fetchCalls = [];
+    global.fetch = async (url, options) => {
+      fetchCalls.push({ url, options });
+      return {
+        status: 200,
+        ok: true,
+        headers: { get: () => null },
+        text: async () =>
+          JSON.stringify({
+            id: 'recBoard',
+            fields: {
+              ThemeMode: 'dark',
+              AccentColor: '#ff00ff',
+              Announcement: 'Hello world',
+            },
+          }),
+      };
+    };
+
+    try {
+      const { handler } = freshModule();
+      const response = await handler({
+        httpMethod: 'PATCH',
+        path: '/.netlify/functions/airtable/boards/recBoard',
+        body: JSON.stringify({
+          themeMode: 'dark',
+          accentColor: '#ff00ff',
+          announcement: 'Hello world',
+        }),
+      });
+
+      assert.equal(fetchCalls.length, 1);
+      const [{ options }] = fetchCalls;
+      assert.equal(options.method, 'PATCH');
+      const parsedBody = JSON.parse(options.body);
+      assert.deepEqual(parsedBody, {
+        fields: {
+          ThemeMode: 'dark',
+          AccentColor: '#ff00ff',
+          Announcement: 'Hello world',
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+      const body = JSON.parse(response.body);
+      assert.equal(body.id, 'recBoard');
+      assert.equal(body.themeMode, 'dark');
+      assert.equal(body.accentColor, '#ff00ff');
+      assert.equal(body.announcement, 'Hello world');
+      assert.deepEqual(body.raw, {
+        ThemeMode: 'dark',
+        AccentColor: '#ff00ff',
+        Announcement: 'Hello world',
+      });
+    } finally {
+      global.fetch = originalFetch;
     }
   });
 });


### PR DESCRIPTION
## Summary
- add theme metadata fields to the board Airtable mappings so they round-trip automatically
- add a handler for PATCH /boards/:id and extend normalisePath to consider original path headers
- cover the board update flow with a unit test that validates theme metadata propagation

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_b_68e434e86f088321aba364d033a02c40